### PR TITLE
UnrealBuildTool parameters fix for UE4 4.18 on Linux

### DIFF
--- a/src/buildtool.js
+++ b/src/buildtool.js
@@ -88,12 +88,12 @@ function getGenerateProjectFilesArgs(info, generateNativeProjectFiles=true, gene
     }
 
     if (generateCodeLiteProjectFiles) {
+        if (!args.find((v) => {return v == '-makefile'})) args.push('-makefile');
         if (!args.find((v) => {return v == '-codelitefile'})) args.push('-codelitefile');
     }
 
     args = args.concat([
-        '-project=',
-        info.projectFilePath,
+        '-project=\"' + info.projectFilePath + "\"",
         '-game',
         '-rocket',
         '-waitmutex'


### PR DESCRIPTION
While trying to use this plugin on VSCode 1.17.2 on linux, with Unreal Editor 4.18-preview 4, I ran into a couple of errors.

Firstly, when generating project files the buildtool helper added arguments with "-project" and the actual project string as separate commands. The output of this was an argument with a space in it, for example:
```
mono /path/to/UnrealBuildTool.exe -makefile -cmakefile -codelitefile -project= /path/to/my/project/Project.uproject -game -rocket -waitmutex -engine
```
The `-project= /path/to/my/project/Project.uproject` is getting interpreted as two different arguments, then UnrealBuildTool returns a error stating it cannot find the target. Removing this space buy putting the `-project=` and `info.projectFilePath` concatenated onto one argument fixes this, and it works fine. I also made a slight tweak to this, to surround the projectFilePath with quotation marks, in case the project path has spaces in it.

The second problem, was when `getGenerateProjectFileArgs` is configured to _only_ generate codeLite project files, it was generating a command like this:
```
mono /path/to/UnrealBuildTool.exe -codelitefile -project=/path/to/my/project/Project.uproject -game -rocket -waitmutex -engine
```
When running this, I was getting "ERROR: Couldn't find platform name."
After some experimentation, I determined that on linux you cannot pass _just_ `-codelitefile`, you must also have `-makefile` as a minimum. So I add that in if it is not present already.

With these two changes, this plugin is working great on VSCode 1.17.2 with Unreal Engine 4.18-preview4. 